### PR TITLE
If the card_id is received, store the sign in

### DIFF
--- a/app/db_repository/db_functions.py
+++ b/app/db_repository/db_functions.py
@@ -17,7 +17,7 @@ class Banner():
                 SELECT *
                 FROM BU_RFID_SCANNER_SESSIONS 
                 LEFT JOIN (
-                    SELECT BU_RFID_SCANNER_SCANS.session_id, COUNT(username) as total
+                    SELECT BU_RFID_SCANNER_SCANS.session_id, COUNT(card_id) as total
                     FROM BU_RFID_SCANNER_SCANS
                     GROUP BY session_id
                 ) count_table 
@@ -83,7 +83,7 @@ class Banner():
         except:
             return False
 
-    def scan_user(self, session_id, card_id, username, first_name, last_name):
+    def scan_user(self, session_id, card_id, username=None, first_name=None, last_name=None):
         try:
             results = self.engine.execute("""
                 INSERT INTO BU_RFID_SCANNER_SCANS (session_id, card_id, username, first_name, last_name, scan_datetime)

--- a/app/views/__init__.py
+++ b/app/views/__init__.py
@@ -162,9 +162,13 @@ class View(FlaskView):
                 alert_type = 'success'
                 alert_message = 'Thank you for signing in, {} {}.'.format(first_name, last_name)
             except:
-                self.banner.scan_user(session_id, card_id)
-                alert_type = 'warning'
-                alert_message = 'Thank you for signing in, {}. Your username could not be found in Banner. Please try again or contact the Help Desk at helpdesk@bethel.edu.'.format(card_id)
+                # if we are able to get the card_id but no data for them, still record their data.
+                if card_id:
+                    self.banner.scan_user(session_id, card_id)
+                    alert_type = 'warning'
+                    alert_message = 'Thank you for signing in, {}. Your username could not be found in Banner. Please try again or contact the Help Desk at helpdesk@bethel.edu.'.format(card_id)
+                else:
+                    alert_message = 'ERROR: Failed to get the card ID. Please try again.'
         else:
             alert_message = 'ERROR: Failed to get the card ID. Please try again.'
 

--- a/app/views/__init__.py
+++ b/app/views/__init__.py
@@ -150,6 +150,7 @@ class View(FlaskView):
 
         alert_type = 'danger'
         if card_data:
+            card_id = ''
             try:
                 card_id = card_data.group(1)
                 username = self.wsapi.get_user_from_prox(card_id).get('username')
@@ -161,7 +162,9 @@ class View(FlaskView):
                 alert_type = 'success'
                 alert_message = 'Thank you for signing in, {} {}.'.format(first_name, last_name)
             except:
-                alert_message = 'ERROR: Failed sign in the user with Card ID, {}'.format(card_id)
+                self.banner.scan_user(session_id, card_id)
+                alert_type = 'warning'
+                alert_message = 'Thank you for signing in, {}. Your username could not be found in Banner. Please try again or contact the Help Desk at helpdesk@bethel.edu.'.format(card_id)
         else:
             alert_message = 'ERROR: Failed to get the card ID. Please try again.'
 


### PR DESCRIPTION
## Description

For users who do not have a BCA (Example: tenants of ANC), we still want to record their sign in.

Fixes #5 

## Size and Type of change

Delete any of these you don't use.

- Small Change - 1 person needs to review this
- New feature

## How Has This Been Tested?

- tested locally by raising an exception after we get the card_id in the scan id method. It triggers the alert and adds to the DB as expected. I also verified that the download CSV method works.

## Checklist:

Only check what applies and what you have done.

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)
