### PR TITLE
fix textarea width in form

### DIFF
--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -91,3 +91,7 @@ body {
 #offline-data-message {
 	display: none;
 }
+
+.set-width {
+	width: 100%;
+}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -113,14 +113,15 @@
               </div>
               <div class="modal-body">
                   <input id='session_id_field' type="hidden" name="session_id" />
-                  <label for="form_name">Name
+                  <label class="set-width" for="form_name">Name
                       <br>
-                      <textarea id='form_name_field' name="form_name" rows="2" cols="50" maxlength="150" required></textarea>
+                      <textarea class="set-width" id='form_name_field' name="form_name" cols="50" rows="2" maxlength="150" required></textarea>
+                  </label>
                   <br>
-                  <label for="form_description">Description
+                  <label class="set-width" for="form_description">Description
                       <br>
                       <p><small>Displays a message on the sign-in screen for this session.</small></p>
-                      <textarea id='form_description_field' name="form_description" rows="10" cols="50" maxlength="1000"></textarea>
+                      <textarea class="set-width" id='form_description_field' name="form_description" rows="10" cols="50" maxlength="1000"></textarea>
                   </label>
 
               </div>


### PR DESCRIPTION
## Description

Text areas in create session form have correct width. Fixes issue when viewing page from safari. 

Fixes https://jira.bethel.edu/browse/ITS-214241

## Size and Type of change

Delete any of these you don't use.

- Small Change - 1 person needs to review this

## How Has This Been Tested?

Please briefly describe the tests that you ran to verify your changes.

Locally, updated css was visible. 

## Checklist:

Only check what applies and what you have done.

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)